### PR TITLE
refactor: pin windicss to a stable working version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+.vscode

--- a/windicss/deps.ts
+++ b/windicss/deps.ts
@@ -1,3 +1,3 @@
-export { default as Processor } from "https://esm.sh/windicss";
-export { HTMLParser } from "https://esm.sh/windicss/utils/parser";
-export { StyleSheet } from "https://esm.sh/windicss/utils/style";
+export { default as Processor } from "https://esm.sh/windicss@3.1.2";
+export { HTMLParser } from "https://esm.sh/windicss@3.1.2/utils/parser";
+export { StyleSheet } from "https://esm.sh/windicss@3.1.2/utils/style";


### PR DESCRIPTION
Should always pin version because windicss might introduce breaking changes in how they structure their project. I will let windicss team know about deno and talk about adding some tests. 

I noticed the `3.1.3` version wasn't working properly. 
