### PR TITLE
windicss: bugfixes & full framework support

### DIFF
--- a/windicss/demo/_config.ts
+++ b/windicss/demo/_config.ts
@@ -5,7 +5,13 @@ const site = lume({
   prettyUrls: false,
 });
 
-site.use(windicss());
+site.use(windicss({
+  config: {
+    shortcuts: {
+      "btn-green": "text-white bg-green-500 hover:bg-green-700",
+    },
+  },
+}));
 site.loadPages([".html"]);
 
 export default site;

--- a/windicss/demo/index.njk
+++ b/windicss/demo/index.njk
@@ -2,7 +2,7 @@
 layout: layout.njk
 ---
 <div class="bg-purple-500">
-  <p>This is the page 1</p>
+  <p>This is page 1</p>
 
-  <a href="page2.html">Go to page 2</a>
+  <a href="page2.html" class="btn-green">Go to page 2</a>
 </div>

--- a/windicss/demo/page2.njk
+++ b/windicss/demo/page2.njk
@@ -2,5 +2,5 @@
 layout: layout.njk
 ---
 <div class="bg-purple-600">
-  <p>This is the page 2</p>
+  <p>This is page 2</p>
 </div>

--- a/windicss/deps.ts
+++ b/windicss/deps.ts
@@ -1,4 +1,6 @@
 export { default as Processor } from "https://esm.sh/windicss@3.1.2";
-export { HTMLParser } from "https://esm.sh/windicss@3.1.2/utils/parser";
+export {
+  CSSParser,
+  HTMLParser,
+} from "https://esm.sh/windicss@3.1.2/utils/parser";
 export { StyleSheet } from "https://esm.sh/windicss@3.1.2/utils/style";
-export { defineConfig } from "https://esm.sh/windicss@3.1.2/helpers";

--- a/windicss/deps.ts
+++ b/windicss/deps.ts
@@ -5,7 +5,4 @@ export {
 } from "https://esm.sh/windicss@3.3.0/utils/parser";
 export { StyleSheet } from "https://esm.sh/windicss@3.3.0/utils/style";
 
-export {
-  Element,
-  HTMLDocument,
-} from "https://deno.land/x/deno_dom@v0.1.19-alpha/deno-dom-wasm.ts";
+export { Element, HTMLDocument } from "lume/deps/dom.ts";

--- a/windicss/deps.ts
+++ b/windicss/deps.ts
@@ -1,3 +1,4 @@
 export { default as Processor } from "https://esm.sh/windicss@3.1.2";
 export { HTMLParser } from "https://esm.sh/windicss@3.1.2/utils/parser";
 export { StyleSheet } from "https://esm.sh/windicss@3.1.2/utils/style";
+export { defineConfig } from "https://esm.sh/windicss@3.1.2/helpers";

--- a/windicss/deps.ts
+++ b/windicss/deps.ts
@@ -1,6 +1,11 @@
-export { default as Processor } from "https://esm.sh/windicss@3.1.2";
+export { default as Processor } from "https://esm.sh/windicss@3.3.0";
 export {
   CSSParser,
   HTMLParser,
-} from "https://esm.sh/windicss@3.1.2/utils/parser";
-export { StyleSheet } from "https://esm.sh/windicss@3.1.2/utils/style";
+} from "https://esm.sh/windicss@3.3.0/utils/parser";
+export { StyleSheet } from "https://esm.sh/windicss@3.3.0/utils/style";
+
+export {
+  Element,
+  HTMLDocument,
+} from "https://deno.land/x/deno_dom@v0.1.19-alpha/deno-dom-wasm.ts";

--- a/windicss/windicss.ts
+++ b/windicss/windicss.ts
@@ -1,7 +1,17 @@
 import { extname } from "lume/deps/path.ts";
 import { SitePage } from "lume/core/filesystem.ts";
 import { Page, Site } from "lume/core.ts";
-import { defineConfig, HTMLParser, Processor, StyleSheet } from "./deps.ts";
+import { CSSParser, HTMLParser, Processor, StyleSheet } from "./deps.ts";
+
+type Mode = "interpret" | "compile";
+export interface Options {
+  minify?: boolean;
+  mode?: Mode;
+  output?: string;
+  // https://github.com/windicss/windicss/blob/main/src/interfaces.ts#L367
+  // https://windicss.org/guide/configuration.html
+  config?: Record<string, unknown>;
+}
 
 /**
  * a lume plugin for windicss, the next generation utility-first css framework
@@ -12,21 +22,23 @@ import { defineConfig, HTMLParser, Processor, StyleSheet } from "./deps.ts";
  * the output css file must be manually included in your document's
  * head e.g. <link rel="stylesheet" href="/windi.css">
  */
-export default function (
-  { minify = false, output = "/windi.css", config = defineConfig({}) } = {},
-) {
+export default function ({
+  minify = false,
+  mode = "interpret",
+  output = "/windi.css",
+  config = {},
+}: Options = {}) {
   return (site: Site) => {
     // create & configure a windicss instance
+    // (config assignment merges provided with defaults)
     const processor = new Processor();
-    processor.loadConfig(config);
+    config = processor.loadConfig(config);
 
     site.addEventListener("afterRender", () => {
       // create & merge stylesheets for all pages
       const stylesheet = site.pages
         .filter((page) => page.dest.ext === ".html")
-        .map((page) =>
-          generateStyles(page, processor, config.preflight as boolean)
-        )
+        .map((page) => windi(page, processor, mode, config))
         .reduce(
           (previous, current) => previous.extend(current, false),
           new StyleSheet(),
@@ -44,19 +56,72 @@ export default function (
   };
 }
 
-export function generateStyles(
+export function windi(
   page: Page,
   processor: Processor,
-  preflight: boolean,
+  mode: Mode,
+  config: Record<string, unknown>,
 ) {
   const content = page.content as string,
-    classes = new HTMLParser(content)
-      .parseClasses()
-      .map((i) => i.result)
-      .join(" "),
-    interpretedSheet = processor.interpret(classes).styleSheet;
-  if (!preflight) return interpretedSheet;
+    parser = new HTMLParser(content);
 
+  // update page content with classnames output from windi
+  // e.g. to expand variant:(class groups) and to support compile mode
+  let stylesheet = new StyleSheet(), html = "", index = 0;
+  for (const className of parser.parseClasses()) {
+    html += content.substring(index, className.start);
+    index = className.end;
+    if (mode === "interpret") {
+      const interpreted = processor.interpret(className.result);
+      html += [...interpreted.success, ...interpreted.ignored].join(" ");
+      stylesheet = stylesheet.extend(interpreted.styleSheet);
+    } else if (mode === "compile") {
+      const compiled = processor.compile(
+        className.result,
+        config.prefix as string,
+      );
+      html += [compiled.className, ...compiled.ignored].join(" ");
+      stylesheet = stylesheet.extend(compiled.styleSheet);
+    }
+  }
+  page.content = html + content.substring(index);
+
+  // attributify: https://windicss.org/features/attributify.html
+  // reduceRight taken from https://github.com/windicss/windicss/blob/main/src/cli/index.ts
+  const attrs: { [key: string]: string | string[] } = parser
+    .parseAttrs()
+    .reduceRight((a: { [key: string]: string | string[] }, b) => {
+      if (b.key === "class" || b.key === "className") return a;
+      if (b.key in a) {
+        a[b.key] = Array.isArray(a[b.key])
+          ? Array.isArray(b.value)
+            ? [...(a[b.key] as string[]), ...b.value]
+            : [...(a[b.key] as string[]), b.value]
+          : [
+            a[b.key] as string,
+            ...(Array.isArray(b.value) ? b.value : [b.value]),
+          ];
+        return a;
+      }
+      return Object.assign(a, { [b.key]: b.value });
+    }, {});
+  const attributified = processor.attributify(attrs);
+  stylesheet = stylesheet.extend(attributified.styleSheet);
+
+  // style blocks: use @apply etc. in a style tag
+  // https://windicss.org/features/directives.html
+  // https://windicss.org/posts/language.html
+  // https://windicss.org/integrations/cli.html#style-block
+  const block = content.match(
+    /(?<=<style lang=['"]windi["']>)[\s\S]*(?=<\/style>)/,
+  );
+  if (block && block.index) {
+    const css = content.slice(block.index, block.index + block[0].length),
+      styleBlock = new CSSParser(css, processor);
+    stylesheet = stylesheet.extend(styleBlock.parse());
+  }
+
+  if (!config.preflight) return stylesheet;
   const preflightSheet = processor.preflight(content);
-  return interpretedSheet.extend(preflightSheet, false);
+  return stylesheet.extend(preflightSheet);
 }

--- a/windicss/windicss.ts
+++ b/windicss/windicss.ts
@@ -1,17 +1,36 @@
 import { extname } from "lume/deps/path.ts";
+import { merge } from "lume/core/utils.ts";
 import { SitePage } from "lume/core/filesystem.ts";
 import { Page, Site } from "lume/core.ts";
 import { CSSParser, HTMLParser, Processor, StyleSheet } from "./deps.ts";
 
-type Mode = "interpret" | "compile";
 export interface Options {
-  minify?: boolean;
-  mode?: Mode;
-  output?: string;
+  minify: boolean;
+  mode: "interpret" | "compile";
+  output: {
+    // ouput mode "file"
+    // = a single file will be created with generated styles
+    //   from across the entire site
+    // output mode "styleTag"
+    // = a <style> tag will be inserted into each page
+    //   containing only the generated styles for that page
+    mode: "file" | "styleTag";
+    filename?: string;
+  };
   // https://github.com/windicss/windicss/blob/main/src/interfaces.ts#L367
   // https://windicss.org/guide/configuration.html
-  config?: Record<string, unknown>;
+  config: Record<string, unknown>;
 }
+
+const defaults = {
+  minify: false,
+  mode: "interpret" as "interpret" | "compile",
+  output: {
+    mode: "file" as "file" | "styleTag",
+    filename: "windi.css",
+  },
+  config: {},
+};
 
 /**
  * a lume plugin for windicss, the next generation utility-first css framework
@@ -22,48 +41,50 @@ export interface Options {
  * the output css file must be manually included in your document's
  * head e.g. <link rel="stylesheet" href="/windi.css">
  */
-export default function ({
-  minify = false,
-  mode = "interpret",
-  output = "/windi.css",
-  config = {},
-}: Options = {}) {
+export default function (userOptions: Partial<Options> = {}) {
+  const options = merge(defaults, userOptions) as Options;
+
   return (site: Site) => {
     // create & configure a windicss instance
     // (config assignment merges provided with defaults)
     const processor = new Processor();
-    config = processor.loadConfig(config);
+    options.config = processor.loadConfig(options.config);
 
     site.addEventListener("afterRender", () => {
-      // create & merge stylesheets for all pages
-      const stylesheet = site.pages
-        .filter((page) => page.dest.ext === ".html")
-        .map((page) => windi(page, processor, mode, config))
-        .reduce(
-          (previous, current) => previous.extend(current, false),
-          new StyleSheet(),
-        )
-        .sort()
-        .combine();
+      const pages = site.pages
+        .filter((page) => page.dest.ext === ".html");
 
-      // output css as a page
-      const ext = extname(output),
-        path = output.slice(0, -ext.length),
-        page = new SitePage({ path, ext });
-      page.content = stylesheet.build(minify);
-      site.pages.push(page);
+      if (options.output.mode === "file" && options.output.filename) {
+        // create & merge stylesheets for all pages
+        const stylesheet = pages
+          .map((page) => windi(page, processor, options))
+          .reduce(
+            (previous, current) => previous.extend(current),
+            new StyleSheet(),
+          )
+          .sort()
+          .combine();
+
+        // output css as a page
+        const ext = extname(options.output.filename),
+          path = options.output.filename.slice(0, -ext.length),
+          page = new SitePage({ path, ext });
+        page.content = stylesheet.build(options.minify);
+        site.pages.push(page);
+      } else if (options.output.mode === "styleTag") {
+        // insert stylesheets directly into pages
+        for (const page of pages) {
+          const stylesheet = windi(page, processor, options);
+          page.content += `<style>${stylesheet.build(options.minify)}</style>`;
+        }
+      }
     });
   };
 }
 
-export function windi(
-  page: Page,
-  processor: Processor,
-  mode: Mode,
-  config: Record<string, unknown>,
-) {
-  const content = page.content as string,
-    parser = new HTMLParser(content);
+export function windi(page: Page, processor: Processor, options: Options) {
+  let content = page.content as string;
+  const parser = new HTMLParser(content);
 
   // update page content with classnames output from windi
   // e.g. to expand variant:(class groups) and to support compile mode
@@ -71,20 +92,20 @@ export function windi(
   for (const className of parser.parseClasses()) {
     html += content.substring(index, className.start);
     index = className.end;
-    if (mode === "interpret") {
+    if (options.mode === "interpret") {
       const interpreted = processor.interpret(className.result);
       html += [...interpreted.success, ...interpreted.ignored].join(" ");
       stylesheet = stylesheet.extend(interpreted.styleSheet);
-    } else if (mode === "compile") {
+    } else if (options.mode === "compile") {
       const compiled = processor.compile(
         className.result,
-        config.prefix as string,
+        options.config.prefix as string || "windi-",
       );
       html += [compiled.className, ...compiled.ignored].join(" ");
       stylesheet = stylesheet.extend(compiled.styleSheet);
     }
   }
-  page.content = html + content.substring(index);
+  content = html + content.substring(index);
 
   // attributify: https://windicss.org/features/attributify.html
   // reduceRight taken from https://github.com/windicss/windicss/blob/main/src/cli/index.ts
@@ -109,19 +130,22 @@ export function windi(
   stylesheet = stylesheet.extend(attributified.styleSheet);
 
   // style blocks: use @apply etc. in a style tag
+  // will always replace the inline style block with the generated styles
   // https://windicss.org/features/directives.html
   // https://windicss.org/posts/language.html
   // https://windicss.org/integrations/cli.html#style-block
-  const block = content.match(
-    /(?<=<style lang=['"]windi["']>)[\s\S]*(?=<\/style>)/,
+  content = content.replace(
+    /<style lang=['"]windi["']>([\s\S]*)<\/style>/,
+    (_match, css) => {
+      return `<style>${
+        new CSSParser(css, processor).parse().build(options.minify)
+      }</style>`;
+    },
   );
-  if (block && block.index) {
-    const css = content.slice(block.index, block.index + block[0].length),
-      styleBlock = new CSSParser(css, processor);
-    stylesheet = stylesheet.extend(styleBlock.parse());
-  }
 
-  if (!config.preflight) return stylesheet;
+  page.content = content;
+
+  if (!options.config.preflight) return stylesheet;
   const preflightSheet = processor.preflight(content);
   return stylesheet.extend(preflightSheet);
 }


### PR DESCRIPTION
hey! i was trying to get windicss working in one of my projects and found a couple of things that weren't working right

`new HTMLParser() ... .join("")` needed a space to process classes separately/properly (`.join(" ")`) -- without the space e.g. if there was `<div class="flex"> <p class="text-red-500 bold"></p> </div>` it would end up being processed as `flextext-red-500 bold`

I've also added support for loading a config, e.g. for customising colours/breakpoints. it's taken as an property of the `.use()` plugin constructor, but of course it could be put in a separate file and `import`ed into your `_config.ts` to use it as per https://windicss.org/guide/configuration.html

~~the only other thing that need to be addressed afaict before this could be considered stable would be handling class/attribute replacement: e.g. for variant groups, attributify and compile modes~~ see comment