### PR TITLE
windi: optional attributify, merge outputs + v1.4.1 compat esbuild/minify

### DIFF
--- a/esbuild/esbuild.ts
+++ b/esbuild/esbuild.ts
@@ -1,5 +1,5 @@
 import { Site } from "lume/core.ts";
-import { merge, warn } from "lume/core/utils.ts";
+import { merge } from "lume/core/utils.ts";
 import { relative } from "lume/deps/path.ts";
 import * as esbuild from "./deps.ts";
 
@@ -53,11 +53,11 @@ export default function (userOptions?: Partial<Options>) {
       );
 
       if (errors.length) {
-        warn("esbuild errors", { errors });
+        site.logger.warn("esbuild errors", { errors });
       }
 
       if (warnings.length) {
-        warn("esbuild warnings", { warnings });
+        site.logger.warn("esbuild warnings", { warnings });
       }
 
       if (outputFiles?.length) {

--- a/minify/minify.ts
+++ b/minify/minify.ts
@@ -1,4 +1,5 @@
-import { Exception, merge } from "lume/core/utils.ts";
+import { Exception } from "lume/core/errors.ts";
+import { merge } from "lume/core/utils.ts";
 import { Page, Site } from "lume/core.ts";
 import { minify as rawMinify, minifyHTML, MinifyHTMLOptions } from "./deps.ts";
 

--- a/windicss/deps.ts
+++ b/windicss/deps.ts
@@ -1,8 +1,10 @@
-export { default as Processor } from "https://esm.sh/windicss@3.3.0";
+export { default as Processor } from "https://esm.sh/windicss@3.4.0";
 export {
   CSSParser,
   HTMLParser,
-} from "https://esm.sh/windicss@3.3.0/utils/parser";
-export { StyleSheet } from "https://esm.sh/windicss@3.3.0/utils/style";
-
-export { Element, HTMLDocument } from "lume/deps/dom.ts";
+} from "https://esm.sh/windicss@3.4.0/utils/parser";
+export { StyleSheet } from "https://esm.sh/windicss@3.4.0/utils/style";
+export {
+  Element,
+  HTMLDocument,
+} from "https://deno.land/x/lume@v1.4.1/deps/dom.ts";

--- a/windicss/windicss.ts
+++ b/windicss/windicss.ts
@@ -1,7 +1,7 @@
-import { extname } from "lume/deps/path.ts";
+import { extname, resolve } from "lume/deps/path.ts";
 import { merge } from "lume/core/utils.ts";
-import { SitePage } from "lume/core/filesystem.ts";
-import { Page, Site } from "lume/core.ts";
+import { Page } from "lume/core/filesystem.ts";
+import { Site } from "lume/core.ts";
 import {
   CSSParser,
   Element,
@@ -15,12 +15,8 @@ export interface Options {
   minify: boolean;
   mode: "interpret" | "compile";
   output: {
-    // ouput mode "file"
-    // = a single file will be created with generated styles
-    //   from across the entire site
-    // output mode "styleTag"
-    // = a <style> tag will be inserted into each page
-    //   containing only the generated styles for that page
+    // ouput mode "file" = single file for all generated styles
+    // output mode "styleTag" = <style> tags inserted per-page
     mode: "file" | "styleTag";
     filename?: string;
   };
@@ -28,9 +24,10 @@ export interface Options {
   // https://windicss.org/guide/configuration.html
   config: Record<string, unknown>;
   // transpile .windi.css files to .css files
-  // https://windicss.org/posts/language.html
-  // note: for this to work the plugin must called BEFORE postcss
-  windiLangFiles: boolean;
+  // or merge .windi.css styles with main windi output
+  // (https://windicss.org/posts/language.html)
+  // note: must be called BEFORE postcss prior to lume v2.0.0
+  windiLangFiles: "merge" | "transpile" | "ignore";
 }
 
 const defaults: Options = {
@@ -41,7 +38,26 @@ const defaults: Options = {
     filename: "/windi.css",
   },
   config: {},
-  windiLangFiles: true,
+  windiLangFiles: "transpile",
+};
+
+const recurseDir = async (
+  path: string,
+  { ignore = [/^\./], extensions = [] as string[] } = {},
+) => {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(path)) {
+    if (ignore.some((pattern) => entry.name.match(pattern))) continue;
+    const name = resolve(path, entry.name);
+    if (entry.isFile) {
+      const ext = extensions.some((ext) => entry.name.endsWith(ext));
+      if (extensions.length && !ext) continue;
+      files.push(name);
+    } else if (entry.isDirectory) {
+      files.push(...(await recurseDir(name, { ignore, extensions })));
+    }
+  }
+  return files;
 };
 
 /**
@@ -62,41 +78,54 @@ export default function (userOptions: Partial<Options> = {}) {
     const processor = new Processor();
     options.config = processor.loadConfig(options.config);
 
-    if (options.windiLangFiles) {
+    if (options.windiLangFiles === "transpile") {
       site.loadAssets([".windi.css"]);
       site.process([".windi.css"], (page) => {
-        const stylesheet = new CSSParser(page.content as string, processor);
-        page.content = stylesheet.parse().build(options.minify);
+        const parser = new CSSParser(page.content as string, processor),
+          stylesheet = parser.parse();
+        page.content = stylesheet.build(options.minify);
         page.dest.ext = ".css";
       });
     }
 
-    site.addEventListener("afterRender", () => {
+    site.addEventListener("afterRender", async () => {
+      let stylesheet = new StyleSheet();
+
+      if (options.windiLangFiles === "merge") {
+        const files = await recurseDir(site.src("/"), {
+          extensions: [".windi.css"],
+        });
+        for (const file of files) {
+          const content = await Deno.readTextFile(file),
+            windilang = new CSSParser(content, processor).parse();
+          stylesheet = stylesheet.extend(windilang);
+        }
+      }
+
       const pages = site.pages
         .filter((page) => page.dest.ext === ".html");
 
       if (options.output.mode === "file" && options.output.filename) {
         // create & merge stylesheets for all pages
-        const stylesheet = pages
+        stylesheet = pages
           .map((page) => windi(page, processor, options))
           .reduce(
             (previous, current) => previous.extend(current),
-            new StyleSheet(),
-          )
-          .sort()
-          .combine();
+            stylesheet,
+          ).sort().combine();
 
         // output css as a page
         const ext = extname(options.output.filename),
           path = options.output.filename.slice(0, -ext.length),
-          page = new SitePage({ path, ext });
+          page = new Page({ path, ext });
         page.content = stylesheet.build(options.minify);
         site.pages.push(page);
       } else if (options.output.mode === "styleTag") {
         // insert stylesheets directly into pages
         for (const page of pages) {
-          const stylesheet = windi(page, processor, options);
-          page.content += `<style>${stylesheet.build(options.minify)}</style>`;
+          const scopedsheet = windi(page, processor, options)
+            .extend(stylesheet).sort().combine();
+          page.content += `<style>${scopedsheet.build(options.minify)}</style>`;
         }
       }
     });
@@ -130,25 +159,27 @@ export function windi(page: Page, processor: Processor, options: Options) {
 
   // attributify: https://windicss.org/features/attributify.html
   // reduceRight taken from https://github.com/windicss/windicss/blob/main/src/cli/index.ts
-  const attrs: { [key: string]: string | string[] } = parser
-    .parseAttrs()
-    .reduceRight((a: { [key: string]: string | string[] }, b) => {
-      if (b.key === "class" || b.key === "className") return a;
-      if (b.key in a) {
-        a[b.key] = Array.isArray(a[b.key])
-          ? Array.isArray(b.value)
-            ? [...(a[b.key] as string[]), ...b.value]
-            : [...(a[b.key] as string[]), b.value]
-          : [
-            a[b.key] as string,
-            ...(Array.isArray(b.value) ? b.value : [b.value]),
-          ];
-        return a;
-      }
-      return Object.assign(a, { [b.key]: b.value });
-    }, {});
-  const attributified = processor.attributify(attrs);
-  stylesheet = stylesheet.extend(attributified.styleSheet);
+  if (options.config.attributify) {
+    const attrs: { [key: string]: string | string[] } = parser
+      .parseAttrs()
+      .reduceRight((a: { [key: string]: string | string[] }, b) => {
+        if (b.key === "class" || b.key === "className") return a;
+        if (b.key in a) {
+          a[b.key] = Array.isArray(a[b.key])
+            ? Array.isArray(b.value)
+              ? [...(a[b.key] as string[]), ...b.value]
+              : [...(a[b.key] as string[]), b.value]
+            : [
+              a[b.key] as string,
+              ...(Array.isArray(b.value) ? b.value : [b.value]),
+            ];
+          return a;
+        }
+        return Object.assign(a, { [b.key]: b.value });
+      }, {});
+    const attributified = processor.attributify(attrs);
+    stylesheet = stylesheet.extend(attributified.styleSheet);
+  }
 
   // style blocks: use @apply etc. in a style tag
   // will always replace the inline style block with the generated styles


### PR DESCRIPTION
- **lume v1.4.1 compatibility:** correct lume dependencies/imports in esbuild, minify & windicss
- **bugfix:** windicss respects the attributify option properly (prev. was perma-on)
- **feature:** `.windi.css` files can be merged with the compiled/interpreted windi output to create a single `.css` file