### PR TITLE
Added Remark plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A repo to test and experiment with plugins for Lume
 
+## Remark
+
+Use [Remark](https://github.com/remarkjs/remark) and [Rehype](https://github.com/rehypejs/rehype) as an alternative markdown processor.
+
 ## Windi CSS
 
 Use [Windi CSS](https://windicss.org/) in your website.

--- a/remark/demo/_config.ts
+++ b/remark/demo/_config.ts
@@ -1,0 +1,23 @@
+import lume from "lume/mod.ts";
+import remark from "../remark.ts";
+import rehypeAutolinkHeadings from "https://esm.sh/rehype-autolink-headings@6.1.1";
+import rehypeExternalLinks from "https://esm.sh/rehype-external-links@1.0.1";
+import remarkSmartyPants from "https://esm.sh/remark-smartypants@2.0.0";
+
+const site = lume();
+
+site.use(remark({
+  remarkPlugins: [
+    remarkSmartyPants
+  ],
+  rehypePlugins: [
+    rehypeExternalLinks,
+    [
+      rehypeAutolinkHeadings, {
+        behavior: "append"
+      }
+    ]
+  ]
+}));
+
+export default site;

--- a/remark/deps.ts
+++ b/remark/deps.ts
@@ -1,0 +1,5 @@
+export { default as rehypeStringify } from "https://esm.sh/rehype-stringify@9.0.3";
+export { default as remarkGfm } from "https://esm.sh/remark-gfm@3.0.1";
+export { default as remarkParse } from "https://esm.sh/remark-parse@10.0.1";
+export { default as remarkRehype } from "https://esm.sh/remark-rehype@10.1.0";
+export * as unified from "https://esm.sh/unified@10.1.2";

--- a/remark/remark.ts
+++ b/remark/remark.ts
@@ -1,0 +1,101 @@
+import loader from "lume/core/loaders/text.ts";
+import { merge } from "lume/core/utils.ts";
+import { unified, remarkParse, remarkGfm, remarkRehype, rehypeStringify } from "./deps.ts";
+
+import type { Data, Engine, Helper, Site } from "lume/core.ts";
+
+export interface Options {
+  /** List of extensions this plugin applies to */
+  extensions: string[],
+
+  /** List of remark plugins to use */
+  remarkPlugins?: unknown[],
+
+  /** List of rehype plugins to use */
+  rehypePlugins?: unknown[]
+}
+
+// Default options
+export const defaults: Options = {
+  extensions: [".md"],
+  // By default, GitHub-flavored markdown is enabled
+  remarkPlugins: [remarkGfm],
+  rehypePlugins: []
+}
+
+export function loadPlugin(plugin: unknown, engine: unified.Processor) {
+  if (Array.isArray(plugin)) {
+    const [pluginWithOps, ...opts] = plugin;
+    engine.use(pluginWithOps, ...opts);
+  } else {
+    // @ts-ignore: Some plugins may not have types available
+    engine.use(plugin);
+  }
+}
+
+/** Template engine to render Markdown files with Remark */
+export class MarkdownEngine implements Engine {
+  engine: unified.Processor;
+
+  constructor(engine: unified.Processor) {
+    this.engine = engine;
+  }
+
+  deleteCache() { }
+
+  render(content: string, data?: Data, filename?: string): Promise<string> {
+    return this.engine.process(content).then(result => result.toString());
+  }
+
+  renderSync(content: string, data?: Data, filename?: string): string {
+    return this.engine.processSync(content).toString();
+  }
+
+  addHelper() { }
+}
+
+/** Register the plugin to support Markdown */
+export default function (userOptions?: Partial<Options>) {
+  const options = merge(defaults, userOptions);
+
+  return function (site: Site) {
+    // @ts-ignore: This expression is not callable
+    const engine = unified.unified();
+
+    // Register remark-parse to generate MDAST
+    // @ts-ignore: remark-parse does not have correct types available
+    engine.use(remarkParse);
+
+    // Register remark plugins
+    options.remarkPlugins?.forEach((plugin: unknown) => loadPlugin(plugin, engine));
+
+    // Register remark-rehype to generate HAST
+    engine.use(remarkRehype, {
+      allowDangerousHtml: true
+    })
+
+    // Register rehype plugins
+    options.rehypePlugins?.forEach((plugin: unknown) => loadPlugin(plugin, engine));
+
+    // Register rehype-stringify to output HTML
+    // @ts-ignore: rehype-stringify does not have correct types available
+    engine.use(rehypeStringify, {
+      allowDangerousHtml: true
+    })
+
+    // Load the pages
+    site.loadPages(options.extensions, loader, new MarkdownEngine(engine));
+
+    // Register the md and mdSync filters
+    site.filter("md", filter as Helper);
+    site.filter("mdSync", filterSync as Helper);
+
+    function filter(string: string): Promise<string> {
+      return engine.process(string?.toString() || "").then(result => result.toString().trim());
+    }
+
+    function filterSync(string: string): string {
+      return engine.processSync(string?.toString() || "").toString().trim();
+    }
+  }
+}


### PR DESCRIPTION
This change adds a Remark plugin to process markdown with [Remark](https://github.com/remarkjs/remark) and generate the subsequent HTML with [Rehype](https://github.com/rehypejs/rehype).

I have used [ esm.sh](https://esm.sh) as the import host because that's what most of the Remark and Rehype ecosystem prefers.