### PR TITLE
Always load remark-gfm

### DIFF
--- a/remark/remark.ts
+++ b/remark/remark.ts
@@ -68,6 +68,11 @@ export default function (userOptions?: Partial<Options>) {
     // Add remark-parse to generate MDAST
     plugins.push(remarkParse);
 
+    // Add default remark plugins
+    defaults.remarkPlugins?.forEach((defaultPlugin) =>
+      plugins.push(defaultPlugin)
+    );
+
     // Add remark plugins
     options.remarkPlugins?.forEach((plugin) => plugins.push(plugin));
 

--- a/remark/remark.ts
+++ b/remark/remark.ts
@@ -24,6 +24,9 @@ export interface Options {
 
   /** Flag to turn on HTML sanitization to prevent XSS */
   sanitize?: boolean;
+
+  /** Flag to override the default plugins */
+  overrideDefaultPlugins?: boolean;
 }
 
 // Default options
@@ -68,10 +71,12 @@ export default function (userOptions?: Partial<Options>) {
     // Add remark-parse to generate MDAST
     plugins.push(remarkParse);
 
-    // Add default remark plugins
-    defaults.remarkPlugins?.forEach((defaultPlugin) =>
-      plugins.push(defaultPlugin)
-    );
+    if (!options.overrideDefaultPlugins) {
+      // Add default remark plugins
+      defaults.remarkPlugins?.forEach((defaultPlugin) =>
+        plugins.push(defaultPlugin)
+      );
+    }
 
     // Add remark plugins
     options.remarkPlugins?.forEach((plugin) => plugins.push(plugin));


### PR DESCRIPTION
Since `merge` does not actually merge arrays, I need to ensure that GFM support is available out-of-the-box. This change enforces that opinion.

GFM is generally a very good out-of-box experience. I don't foresee a usecase where a user might need to override this opinion. @oscarotero Do you think there should be an option to override this?