### PR TITLE
Allow data enrichment by Remark / Rehype plugins

### DIFF
--- a/remark/deps.ts
+++ b/remark/deps.ts
@@ -4,4 +4,8 @@ export { default as rehypeStringify } from "https://esm.sh/rehype-stringify@9.0.
 export { default as remarkGfm } from "https://esm.sh/remark-gfm@3.0.1";
 export { default as remarkParse } from "https://esm.sh/remark-parse@10.0.1";
 export { default as remarkRehype } from "https://esm.sh/remark-rehype@10.1.0";
+export * as hastUtilHasProperty from "https://esm.sh/hast-util-has-property@2.0.0";
+export * as hastUtilHeadingRank from "https://esm.sh/hast-util-heading-rank@2.1.0";
+export * as hastUtilToString from "https://esm.sh/hast-util-to-string@2.0.0";
 export * as unified from "https://esm.sh/unified@10.1.2";
+export * as unistUtilVisit from "https://esm.sh/unist-util-visit@4.1.0";

--- a/remark/deps.ts
+++ b/remark/deps.ts
@@ -4,8 +4,4 @@ export { default as rehypeStringify } from "https://esm.sh/rehype-stringify@9.0.
 export { default as remarkGfm } from "https://esm.sh/remark-gfm@3.0.1";
 export { default as remarkParse } from "https://esm.sh/remark-parse@10.0.1";
 export { default as remarkRehype } from "https://esm.sh/remark-rehype@10.1.0";
-export * as hastUtilHasProperty from "https://esm.sh/hast-util-has-property@2.0.0";
-export * as hastUtilHeadingRank from "https://esm.sh/hast-util-heading-rank@2.1.0";
-export * as hastUtilToString from "https://esm.sh/hast-util-to-string@2.0.0";
 export * as unified from "https://esm.sh/unified@10.1.2";
-export * as unistUtilVisit from "https://esm.sh/unist-util-visit@4.1.0";


### PR DESCRIPTION
This change collects headings using Rehype and exposes it as an array through the `Data`. People can generate a table of contents using this data.

The only prerequisite for this to work is that each heading in the document should have an `id` associated with it. Which means that until and unless a user adds [`remark-slug`](https://github.com/remarkjs/remark-slug) in the list of Remark plugins, or [`remark-slugify`](https://github.com/Microflash/rehype-slugify) in the list of Rehype plugins, this will return a blank array.