### PR TITLE
Persist vfile metadata on Page

### DIFF
--- a/remark/remark.ts
+++ b/remark/remark.ts
@@ -54,7 +54,7 @@ export class MarkdownEngine implements Engine {
   ): Promise<string> {
     return (await this.engine.process({
       value: content,
-      data: data || {},
+      data: data.page.data || {},
       path: filename,
     })).toString();
   }
@@ -62,7 +62,7 @@ export class MarkdownEngine implements Engine {
   renderSync(content: string, data?: Data, filename?: string): string {
     return this.engine.processSync({
       value: content,
-      data: data || {},
+      data: data.page.data || {},
       path: filename,
     }).toString();
   }

--- a/remark/remark.ts
+++ b/remark/remark.ts
@@ -54,7 +54,7 @@ export class MarkdownEngine implements Engine {
   ): Promise<string> {
     return (await this.engine.process({
       value: content,
-      data: data.page.data || {},
+      data: data.page?.data || {},
       path: filename,
     })).toString();
   }
@@ -62,7 +62,7 @@ export class MarkdownEngine implements Engine {
   renderSync(content: string, data?: Data, filename?: string): string {
     return this.engine.processSync({
       value: content,
-      data: data.page.data || {},
+      data: data.page?.data || {},
       path: filename,
     }).toString();
   }


### PR DESCRIPTION
This change stores Remark's `vfile` metadata on the `Data` object of a `Page` so that it is persistent and available for search and pagination. Accompanies https://github.com/lumeland/lume/pull/240 and closes https://github.com/lumeland/lume/issues/219