### PR TITLE
Added exclude option to sitemap plugin

### DIFF
--- a/sitemap/sitemap.ts
+++ b/sitemap/sitemap.ts
@@ -9,9 +9,6 @@ export interface Options {
   /** The query to search pages included in the sitemap */
   query: string[];
 
-  /** The pages to exclude from the sitemap */
-  excludes: string[];
-
   /** The values to sort the sitemap */
   sort: string[];
 }
@@ -19,7 +16,6 @@ export interface Options {
 // Default options
 export const defaults: Options = {
   query: [],
-  excludes: [],
   sort: ["url=asc"],
 };
 
@@ -41,10 +37,11 @@ export default function (userOptions?: Partial<Options>) {
       const search = site.globalData.search as Search;
       let sitemapPages = search.pages(options.query, options.sort);
 
-      // Filter to remove `excludes` pages
-      if (Array.isArray(options.excludes) && options?.excludes?.length) {
-        sitemapPages = sitemapPages.filter((page) =>
-          !options.excludes.some((exclude) => page.dest.path.includes(exclude))
+      const { page404 } = site.options.server;
+
+      if (page404) {
+        sitemapPages = sitemapPages.filter((page: Page) =>
+          page.data.url !== page404
         );
       }
 
@@ -58,7 +55,7 @@ export default function (userOptions?: Partial<Options>) {
   ${sitemapPages.map((page: Page) => {
     return `<url>
     <loc>${site.url(page.data.url as string, true)}</loc>
-    <lastmod>${page.data.date?.toISOString() as string}</lastmod>
+    <lastmod>${page?.data?.date?.toISOString() as string}</lastmod>
   </url>
   `}).join("").trim()}
 </urlset>`.trim();

--- a/sitemap/sitemap.ts
+++ b/sitemap/sitemap.ts
@@ -9,6 +9,9 @@ export interface Options {
   /** The query to search pages included in the sitemap */
   query: string[];
 
+  /** The pages to exclude from the sitemap */
+  excludes: string[];
+
   /** The values to sort the sitemap */
   sort: string[];
 }
@@ -16,6 +19,7 @@ export interface Options {
 // Default options
 export const defaults: Options = {
   query: [],
+  excludes: [],
   sort: ["url=asc"],
 };
 
@@ -35,7 +39,14 @@ export default function (userOptions?: Partial<Options>) {
     function getSitemapContent(site: Site) {
       // Get the search instance from the global data
       const search = site.globalData.search as Search;
-      const sitemapPages = search.pages(options.query, options.sort);
+      let sitemapPages = search.pages(options.query, options.sort);
+
+      // Filter to remove `excludes` pages
+      if (Array.isArray(options.excludes) && options?.excludes?.length) {
+        sitemapPages = sitemapPages.filter((page) =>
+          !options.excludes.some((exclude) => page.dest.path.includes(exclude))
+        );
+      }
 
       // Sort the pages
       sitemapPages.sort(buildSort(options.sort));
@@ -47,7 +58,7 @@ export default function (userOptions?: Partial<Options>) {
   ${sitemapPages.map((page: Page) => {
     return `<url>
     <loc>${site.url(page.data.url as string, true)}</loc>
-    <lastmod>${page?.data?.date?.toISOString().slice(0, 10) as string}</lastmod>
+    <lastmod>${page.data.date?.toISOString() as string}</lastmod>
   </url>
   `}).join("").trim()}
 </urlset>`.trim();


### PR DESCRIPTION
### Reference Issues/PRs

none

### What does this implement fix?

I added an `excludes` option to the `interface Options` for two reasons:

- It is a must to exclude the `404` page from the sitemap (see [more info](https://www.quora.com/Should-404-pages-feature-in-your-sitemap-xml-sitemap-404-webmasters))
- When you use `query`, only pages present in the query `Array` are included. I was not able to to make one query with multiple conditions with variations. I wanted to include the `/` index page, `/blog/` the blog page (including `/blog/2/` etc. for paginations), `/blog/any-blog-slug-title/` pages, `/about/` page, but exclude `/404/` and all `blog/tag/**/*` blog post tag pages.

You can now just use this code and don't need a complicated query.
```js
.use(sitemap({
  excludes: ["/404/", "/blog/tag/"],
}))
```