### PR TITLE
Specify import scripts

### DIFF
--- a/csp/mod.ts
+++ b/csp/mod.ts
@@ -1,5 +1,9 @@
-import type { Middleware, RequestHandler } from "lume/core/";
-import { isPlainObject, merge } from "lume/core/utils/";
+import type { Middleware, RequestHandler } from "lume/core/server.ts";
+import { isPlainObject, merge } from "lume/core/utils/object.ts";
+
+//import { readFile } from "lume/core/utils/read.ts";
+//import { merge } from "lume/core/utils/object.ts";
+//import { posix } from "lume/deps/path.ts";
 
 const DEFAULT_MAX_AGE = 365 * 86400;
 

--- a/csp/mod.ts
+++ b/csp/mod.ts
@@ -1,4 +1,4 @@
-import type { Middleware, RequestHandler } from "lume/core.ts";
+import type { Middleware, RequestHandler } from "lume/core/";
 import { isPlainObject, merge } from "lume/core/utils/";
 
 const DEFAULT_MAX_AGE = 365 * 86400;

--- a/csp/mod.ts
+++ b/csp/mod.ts
@@ -1,5 +1,5 @@
 import type { Middleware, RequestHandler } from "lume/core.ts";
-import { isPlainObject, merge } from "lume/core/utils.ts";
+import { isPlainObject, merge } from "lume/core/utils/";
 
 const DEFAULT_MAX_AGE = 365 * 86400;
 

--- a/csp/mod.ts
+++ b/csp/mod.ts
@@ -1,10 +1,6 @@
 import type { Middleware, RequestHandler } from "lume/core/server.ts";
 import { isPlainObject, merge } from "lume/core/utils/object.ts";
 
-//import { readFile } from "lume/core/utils/read.ts";
-//import { merge } from "lume/core/utils/object.ts";
-//import { posix } from "lume/deps/path.ts";
-
 const DEFAULT_MAX_AGE = 365 * 86400;
 
 interface StrictTransportSecurityOptions {


### PR DESCRIPTION
For some reason, this experimental plugin stopped working. I noticed it, when trying to add security headers to a site being built on Lume 2.4.1 and Deno 2.x, and hosted on Deno Deploy. The error thrown in the build log was a 404, and when I searched it, there were mentions that it meant the script being sourced on import was not there or had been moved. I looked for the scripts with the functions under lumeland/lume, and specified them.

Secondly, specifying `maxAge: DEFAULT_MAX_AGE` in my `serve.ts` failed, with the build process giving an error about a missing reference. Respecifying as a value works: 

```
// pass your preferred security header options:
server.use(csp({
  "Strict-Transport-Security": {
    maxAge: 365 * 24 * 60 * 60, // one year
    includeSubDomains: true,
    preload: true,
  },
  "Referrer-Policy": ["no-referrer", "strict-origin-when-cross-origin"],
  "X-Frame-Options": true,
  "X-Content-Type-Options": true,
  "X-XSS-Protection": true,
  "X-Permitted-Cross-Domain-Policies": true,
  "X-Powered-By": "Lume and sweat, blood, and tears",
}));
```

The discord has it being called as `DEFAULT_MAX_AGE`, and I _think_ I was using it before,  so I am not sure why it failed. 