### PR TITLE
New plugin: downloader

### DIFF
--- a/downloader/demo/_config.ts
+++ b/downloader/demo/_config.ts
@@ -1,0 +1,11 @@
+import lume from "lume/mod.ts";
+import downloader from "../mod.ts";
+
+const site = lume();
+
+site.use(downloader({
+	origins: ["lume.land"],
+	attribute: "add"
+}));
+
+export default site;

--- a/downloader/demo/deno.json
+++ b/downloader/demo/deno.json
@@ -1,0 +1,27 @@
+{
+  "tasks": {
+    "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",
+    "build": "deno task lume",
+    "serve": "deno task lume -s"
+  },
+  "lock": false,
+  "imports": {
+    "lume/": "https://deno.land/x/lume@v3.0.1/",
+    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.9/jsx-runtime.ts"
+  },
+  "compilerOptions": {
+    "types": [
+      "lume/types.ts"
+    ],
+    "jsx": "react-jsx",
+    "jsxImportSource": "lume"
+  },
+  "unstable": [
+    "temporal"
+  ],
+  "lint": {
+    "plugins": [
+      "https://deno.land/x/lume@v3.0.1/lint.ts"
+    ]
+  }
+}

--- a/downloader/demo/index.vto
+++ b/downloader/demo/index.vto
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+  <title>Demo</title>
+</head>
+<body>
+  <img src="https://lume.land/img/showcase/lume.webp" add>
+</body>
+</html>

--- a/downloader/mod.ts
+++ b/downloader/mod.ts
@@ -1,0 +1,76 @@
+import type Site from "lume/core/site.ts";
+
+import { merge } from "lume/core/utils/object.ts";
+import { isUrl } from "lume/core/utils/path.ts";
+import { read } from "lume/core/utils/read.ts";
+import { posix } from "lume/deps/path.ts";
+import modifyUrls from "lume/plugins/modify_urls.ts";
+
+export interface Options {
+  /** Domains to download images from */
+  origins: string[];
+
+  /** The folder where the images will be saved */
+  folder: string;
+
+  /** CSS selector the element needs to match */
+  selector: string;
+
+  /** Attribute to use as selector. Unlike with `selector`, it's possible to assign the attribute a value to manually define a target file name. */
+  attribute: string;
+}
+
+export const defaults: Options = {
+  origins: [],
+  folder: "/_assets",
+  selector: "img,source,use",
+  attribute: "",
+};
+
+export function downloader(userOptions?: Partial<Options>) {
+  const options = merge(defaults, userOptions);
+
+  return (site: Site) => {
+    site.use(modifyUrls({ fn: download }));
+
+    async function download(path: string, _page: Lume.Page, element?: Element) {
+      const [pathAndQuery, frag] = path.split("#", 2);
+
+      if (
+        !isUrl(path) ||
+        !pathAndQuery ||
+        !options.origins.includes(new URL(path).host) ||
+        (element && options.selector && !element.matches(options.selector))
+      ) {
+        return path;
+      }
+
+      let url;
+
+      if (options.attribute) {
+        if (element && !element.matches(`[${options.attribute}]`)) {
+          return path;
+        }
+
+        url = element?.getAttribute(options.attribute);
+      }
+
+      const content = await read(pathAndQuery, true);
+
+      if (!url) {
+        const filename = posix.basename(pathAndQuery);
+        const hash = await crypto.subtle.digest("SHA-1", content);
+        const hashHex = new Uint8Array(hash).toHex();
+        url = posix.join(options.folder, `${hashHex}-${filename}`);
+      }
+
+      const page = await site.getOrCreatePage(url);
+      page.content = content;
+      page.src.ext = posix.extname(path);
+
+      return frag ? `${url}#${frag}` : url;
+    }
+  };
+}
+
+export default downloader;


### PR DESCRIPTION
Supersedes lumeland/lume#847

Adds a new `downloader` plugin which adds remote files to the site dynamically. This is useful for websites based on a headless CMS like Strapi where registering individual files with `site.add()` may not be feasible.